### PR TITLE
Fixed buggy grid

### DIFF
--- a/assets/scripts/templates/get-surveys.handlebars
+++ b/assets/scripts/templates/get-surveys.handlebars
@@ -29,22 +29,22 @@
           <div class="modal-header update-header">
             <h5 class="modal-title">Update</h4>
               <!--this puts the "x" in the corner-->
-              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-
-
-            <form class="update-survey" data-id="{{survey._id}}" data-one="{{survey.one._id}}" data-two="{{survey.two._id}}>
-              <input type="text" class="form-control validate survey-update" name="survey[title]" placeholder="Title: {{survey.title}}">
-              <input type="text" class="form-control validate survey-update" name="survey[answer]" placeholder="Answer 1: {{survey.one.title}}">
-              <input type="text" class="form-control validate survey-update" name="survey[answer2]" placeholder="Answer 2: {{survey.two.title}}">
-
-              <button class="modal-footer btn btn-warning update" type="submit">Confirm</button>
-            </form>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
           </div>
+
+          <form class="update-survey" data-id="{{survey._id}}" data-one="{{survey.one._id}}" data-two="{{survey.two._id}}">
+
+            <input type="text" class="form-control validate survey-update" name="survey[title]" placeholder="Title: {{survey.title}}">
+            <input type="text" class="form-control validate survey-update" name="survey[answer]" placeholder="Answer 1: {{survey.one.title}}">
+            <input type="text" class="form-control validate survey-update" name="survey[answer2]" placeholder="Answer 2: {{survey.two.title}}">
+
+            <button class="modal-footer btn btn-warning update" type="submit">Confirm</button>
+          </form>
         </div>
       </div>
+    </div>
   </div>
 </div>
 {{/each}}

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -77,11 +77,12 @@ h1 {
   margin: 1rem auto;
   width: 75%;
   display: grid;
-  grid-template: repeat(3, 1fr) / repeat(3, 1fr);
+  grid-template-columns: repeat(3, 1fr);
+  grid-auto-rows: 1fr;
 }
+
 .card {
   background-color: #c9d0db;
-  opacity: 0.95;
 }
 
 .card-body {


### PR DESCRIPTION
Grid settings were conflicting with update modal

index.scss
-- Removed opacity setting from .card, which was causing the issue
-- Changed grid settings on #my-survey-content to:
      grid-template-columns: repeat(3, 1fr);
      grid-auto-rows: 1fr;
which still needs work and an issue has been opened in the queue for it

get-surveys.handlebars
-- Added missing closing div from conflict resolution in github
-- Fixed errors in tab structure