### PR TITLE
Fixed grid and set GET to one user

### DIFF
--- a/assets/scripts/surveys/ui.js
+++ b/assets/scripts/surveys/ui.js
@@ -20,9 +20,9 @@ const onUpdateSurveySuccess = (response) => {
   $('#').text('You have successfully updated your survey!')
 }
 const onGetYourSurveysSuccess = (data) => {
-  console.log(data)
   $('#display-my-surveys-message').text('Your serveys are displayed below:')
-  const getSurveysHtml = getSurveysTemplate({ surveys: data.surveys })
+  const ownedSurveys = data.surveys.filter(survey => survey.owner === store.user._id)
+  const getSurveysHtml = getSurveysTemplate({ surveys: ownedSurveys})
   $('#my-survey-content').html(getSurveysHtml)
 }
 const onDeleteSurveySuccess = (response) => {

--- a/assets/scripts/templates/get-surveys.handlebars
+++ b/assets/scripts/templates/get-surveys.handlebars
@@ -1,17 +1,19 @@
 {{#each surveys as |survey|}}
 {{log survey}}
-<div class="card">
-  <button type="button" class="card-header btn" data-toggle="collapse" data-target="#collapse-buttons-{{survey._id}}">
+{{log survey.owner}}
+<div class="card col-md-4">
+  <div class="card-header" data-toggle="collapse" data-target="#collapse-buttons-{{survey._id}}">
     <section>
       <h2>{{survey.title}}</h2>
-      <br></br>
+      <br>
       <p class="handlebars-q-and-a">
-        Would you rather: {{survey.question}}
-        {{survey.one.title}} or
+        Would you rather:
+        {{survey.one.title}}
+        <br> -or- <br>
         {{survey.two.title}}
       </p>
     </section>
-  </button>
+  </div>
 
   <div class="collapse sub-card" id="collapse-buttons-{{survey._id}}">
     <div class="container" >
@@ -34,8 +36,8 @@
             </button>
           </div>
 
-          <form class="update-survey" data-id="{{survey._id}}" data-one="{{survey.one._id}}" data-two="{{survey.two._id}}">
 
+          <form class="update-survey" data-id="{{survey._id}}" data-one="{{survey.one._id}}" data-two="{{survey.two._id}}">
             <input type="text" class="form-control validate survey-update" name="survey[title]" placeholder="Title: {{survey.title}}">
             <input type="text" class="form-control validate survey-update" name="survey[answer]" placeholder="Answer 1: {{survey.one.title}}">
             <input type="text" class="form-control validate survey-update" name="survey[answer2]" placeholder="Answer 2: {{survey.two.title}}">

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -29,9 +29,7 @@ h1, .user-message, p {
 h1 {
   margin-top: 1rem;
 }
-.handlebars-q-and-a {
-  color: black;
-}
+
 .user-message {
   margin-bottom: 1rem;
 }
@@ -76,18 +74,31 @@ h1 {
 #my-survey-content {
   margin: 1rem auto;
   width: 75%;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-auto-rows: 1fr;
 }
 
 .card {
-  background-color: #c9d0db;
+  display: grid;
+  grid-template-rows: auto auto 0px;
+  cursor: pointer;
+}
+
+.card-header {
+  background-color: transparent;
+  border-bottom: 0;
 }
 
 .card-body {
   margin: 2rem auto;
   max-width: 800px;
+}
+
+.sub-card {
+  align-self: end;
+}
+
+.handlebars-q-and-a {
+  color: black;
+  word-break: break-all;
 }
 
 .page-mask {


### PR DESCRIPTION
surveys/ui.js
-- Created a function ownedSurveys that checks if the survey's owner
matches the current logged in user and filters all the surveys to just
return what has been matched
-- Updated getSurveysTemplate to take { surveys: ownedSurveys} so only
what is owned will be displayed

get-surveys.handlebars
-- Added "col-md-4" to the card class
-- Added semantic spacing inside the card to aid visual separation of
the two answers
-- Fixed missing " from the form

index.scss
-- Removed display settings from #my-survey-content
-- Set display: grid on the card, declared the grid template to account
for the disparate heights and to fully hide the update modal from
taking up any space on the page
-- Set a cursor to indicate to the user that a survey is clickable
-- Pushed the buttons (.sub-card) to the bottom of the card
-- Moved the .handlebars-q-and-a to be grouped with the rest of the card
styling